### PR TITLE
fix(routes): Add ending slash in city component template

### DIFF
--- a/routes/src/app/city-module/city.component.ts
+++ b/routes/src/app/city-module/city.component.ts
@@ -7,7 +7,7 @@ import { Component, OnInit } from '@angular/core';
     <img src="https://augury.angular.io/images/camera.svg" width="20" height="20" align="center"> <a routerLink="city1" routerLinkActive="active">City 1</a>
     <a routerLink="city2" routerLinkActive="active">City 2</a>
     <a routerLink="city3" routerLinkActive="active">City 3</a>
-    <router-outlet><router-outlet>
+    <router-outlet></router-outlet>
   `,
   styles: [`
     a.active {


### PR DESCRIPTION
Fixes issue in [augury repo](https://github.com/rangle/augury/issues/1035) about component tree seeing an extra `router-outlet`.